### PR TITLE
Determine whether an input method has uncommitted ("marked") text when p...

### DIFF
--- a/TelegramTest/TMGrowingTextView.m
+++ b/TelegramTest/TMGrowingTextView.m
@@ -394,7 +394,8 @@
     //numpad enter fix
     if(!isEnter && e.keyCode ==  0x4C)
         return YES;
-    return (flags == 0 || flags == 65536) && isEnter;
+    return (flags == 0 || flags == 65536) && isEnter
+            && !self.hasMarkedText; //Determine whether an input method has uncommitted ("marked") text
 }
 
 - (void) keyDown:(NSEvent *)theEvent {


### PR DESCRIPTION
...ress enter

If user is typing with an non-english input method, do not send message out when he press enter.
![image](https://cloud.githubusercontent.com/assets/648674/5842313/c40d8ccc-a1de-11e4-8b00-95ffcdea3363.png)