### PR TITLE
Fix IME issue

### DIFF
--- a/TelegramTest/TMGrowingTextView.m
+++ b/TelegramTest/TMGrowingTextView.m
@@ -389,11 +389,12 @@
 
 - (BOOL)isEnterEvent:(NSEvent *)e {
     NSUInteger flags = (e.modifierFlags & NSDeviceIndependentModifierFlagsMask);
-    BOOL isEnter = (e.keyCode == 0x24); // VK_RETURN
-//    DLog(@"log %lu", (unsigned long)flags);
-    //numpad enter fix
-    if(!isEnter && e.keyCode ==  0x4C)
-        return YES;
+    //    DLog(@"log %lu", (unsigned long)flags);
+    //numpad enter (0x4C) fix
+    BOOL isEnter = (e.keyCode == 0x24 || e.keyCode ==  0x4C); // VK_RETURN
+    // Fix some IME if marked text (select characters) do not send Enter. ex. Chinese, Japenese.
+    if ([self hasMarkedText]) // AppKit NSTextInputClient
+        return NO;
     return (flags == 0 || flags == 65536) && isEnter;
 }
 


### PR DESCRIPTION
Fix some IME if marked text (select characters) do not send Enter.
ex. Chinese, Japenese.

https://developer.apple.com/library/mac/documentation/Cocoa/Reference/NSTextInputClient_Protocol/index.html#//apple_ref/occ/intfm/NSTextInputClient/hasMarkedText
