### PR TITLE
URL Scheme detector

### DIFF
--- a/Telegram.xcodeproj/project.pbxproj
+++ b/Telegram.xcodeproj/project.pbxproj
@@ -219,6 +219,7 @@
 		0AF4F4AA189D5C72004BA4DF /* MessageTableItemServiceMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AF4F4A9189D5C72004BA4DF /* MessageTableItemServiceMessage.m */; };
 		0AF4F4AD189D5CD5004BA4DF /* MessageTableCellServiceMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AF4F4AC189D5CD5004BA4DF /* MessageTableCellServiceMessage.m */; };
 		0AFE39FD18ED752D0014B525 /* MessageTableItemGif.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AFE39FC18ED752D0014B525 /* MessageTableItemGif.m */; };
+		477074D51A967A77002484B7 /* known-url-schemes.txt in Resources */ = {isa = PBXBuildFile; fileRef = 477074D41A967A77002484B7 /* known-url-schemes.txt */; };
 		C2002D0319990F10002A1915 /* BroadcastInfoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C2002D0219990F10002A1915 /* BroadcastInfoViewController.m */; };
 		C2002D0619994D7A002A1915 /* BroadcastInfoHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = C2002D0519994D7A002A1915 /* BroadcastInfoHeaderView.m */; };
 		C202D96718E9D67A0060238B /* TMClickTextFieldView.m in Sources */ = {isa = PBXBuildFile; fileRef = C202D96618E9D67A0060238B /* TMClickTextFieldView.m */; };
@@ -1160,6 +1161,7 @@
 		0AF4F4AC189D5CD5004BA4DF /* MessageTableCellServiceMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MessageTableCellServiceMessage.m; sourceTree = "<group>"; };
 		0AFE39FB18ED752D0014B525 /* MessageTableItemGif.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageTableItemGif.h; sourceTree = "<group>"; };
 		0AFE39FC18ED752D0014B525 /* MessageTableItemGif.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MessageTableItemGif.m; sourceTree = "<group>"; };
+		477074D41A967A77002484B7 /* known-url-schemes.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "known-url-schemes.txt"; sourceTree = "<group>"; };
 		C2002D0119990F10002A1915 /* BroadcastInfoViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BroadcastInfoViewController.h; sourceTree = "<group>"; };
 		C2002D0219990F10002A1915 /* BroadcastInfoViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BroadcastInfoViewController.m; sourceTree = "<group>"; };
 		C2002D0419994D7A002A1915 /* BroadcastInfoHeaderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BroadcastInfoHeaderView.h; sourceTree = "<group>"; };
@@ -4197,6 +4199,7 @@
 				CEB09E6917DAFC250055F150 /* Telegraph-Prefix.pch */,
 				CE46A2571854B68F00D6EF14 /* Localizable.strings */,
 				C2B1730B19A3BF43003FBA23 /* Application.h */,
+				477074D41A967A77002484B7 /* known-url-schemes.txt */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -4829,6 +4832,7 @@
 				C2A5C00818E17C630021BE68 /* SettingsWindowController.xib in Resources */,
 				CE46A2551854B68F00D6EF14 /* Localizable.strings in Resources */,
 				0A9EDC621897BA0E0037E1BC /* Rebel-Info.plist in Resources */,
+				477074D51A967A77002484B7 /* known-url-schemes.txt in Resources */,
 				0A9EDC4B1897BA0E0037E1BC /* InfoPlist.strings in Resources */,
 				C270C5B218A13FB9005D80E0 /* mime-types.txt in Resources */,
 				0AA17C04183D825E004CE1A1 /* dsa_pub.pem in Resources */,

--- a/TelegramTest/FileUtils.h
+++ b/TelegramTest/FileUtils.h
@@ -54,6 +54,7 @@ void alert(NSString *text, NSString *info);
 void alert_bad_files(NSArray *bad_files);
 void confirm(NSString *text, NSString *info, void (^block)(void), void (^cancelBlock)(void));
 
+NSArray *urlSchemes();
 NSArray *mediaTypes();
 NSArray *videoTypes();
 NSArray *imageTypes();

--- a/TelegramTest/FileUtils.m
+++ b/TelegramTest/FileUtils.m
@@ -421,6 +421,11 @@ void playSentMessage(BOOL play) {
 
 }
 
+NSArray *urlSchemes() {
+    NSString *scheme = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:[NSString stringWithFormat:@"known-url-schemes.txt"]];
+    return [[[NSString alloc] initWithContentsOfFile:scheme encoding:NSUTF8StringEncoding error:nil] componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+}
+
 NSArray *mediaTypes() {
     return @[@"png", @"tiff", @"jpeg", @"jpg", @"mp4",@"mov",@"avi"];
 }
@@ -563,7 +568,15 @@ void open_link(NSString *link) {
     }
     
     
-    if(![link hasPrefix:@"http"] && ![link hasPrefix:@"ftp"]) {
+    NSArray *schemes = urlSchemes();
+    BOOL hasSchemeInLink = false;
+    for (NSString *uri in schemes) {
+        hasSchemeInLink = [link hasPrefix:uri];
+        if (hasSchemeInLink)
+            break;
+    }
+    
+    if(![link hasPrefix:@"http"] && ![link hasPrefix:@"ftp"] && !hasSchemeInLink) {
         
         if(!NSStringIsValidEmail(link)) {
             link = [@"http://" stringByAppendingString:link];

--- a/TelegramTest/NSString+FindURLs.m
+++ b/TelegramTest/NSString+FindURLs.m
@@ -64,20 +64,65 @@
         
     }];
     
-    //detect range of URL Schemes
+    //Load the list on the regex
+    NSArray *schemesToFind = @[@"spotify:", @"x-apple.systempreferences://"]; //dumb version
+    NSString *schemeRegexString = @"";
+    for (NSString *scheme in schemesToFind) {
+        schemeRegexString = [schemeRegexString stringByAppendingString:[NSString stringWithFormat:@"(%@.+)|", scheme]];
+    }
+    //remove last character of string |
+    schemeRegexString = [schemeRegexString substringToIndex:schemeRegexString.length-(schemeRegexString.length>0)];
     
-    // Run the following command to have a list of schemes available
-    //System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -dump | egrep "(bindings.*\:$)"|sort
-    
-    
-    //Load the list on the first run to memory
+    //detect occurence of array into string
+    NSRegularExpression *schemeRegex = [NSRegularExpression regularExpressionWithPattern:schemeRegexString options:0 error:&error];
     
     
     //check the contents of messages against the schemes (Regex or other?)
-    
+    NSArray* schemeResult = [schemeRegex matchesInString:self options:0 range:NSMakeRange(0, [self length])];
     //return the range of URL scheme to program
+    NSArray* newResult = [results arrayByAddingObjectsFromArray:schemeResult];
     
-   return [results arrayByAddingObjectsFromArray:userNames];
+    return [newResult arrayByAddingObjectsFromArray:userNames];;
 }
+
+
+
+/*
+ //the following code has been commented because there's no programatic way of determining all the URL shchemes presented on a system, thus forcing the creation of the .plist for handling known URL schemes
+-(NSArray *) listOfURIsOnTheSystem {
+    NSPipe *pipe = [NSPipe pipe];
+    NSFileHandle *file = pipe.fileHandleForReading;
+    
+    NSTask *task = [[NSTask alloc] init];
+    
+    // Run the following command to have a list of schemes available
+    //System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -dump | egrep "(bindings.*\:$)"|sort
+    task.launchPath = @"/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister";
+    task.arguments = @[@"-dump",@"|egrep", @"\"(bindings.*\\:$)\"|sort"];
+    task.standardOutput = pipe;
+    
+    //Run
+    [task launch];
+    
+    NSData *data = [file readDataToEndOfFile];
+    [file closeFile];
+    
+    NSString * output = [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
+    
+    NSError *error = nil;
+    
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"(bindings.*\\:$)" options:0 error:&error];
+    
+    if (error) {
+        NSAlert *alert = [[NSAlert alloc] init] ;
+        [alert setMessageText:error.localizedDescription];
+        [alert runModal];
+        return @[];
+    }
+    
+    return @[];
+    
+}
+ */
 
 @end

--- a/TelegramTest/NSString+FindURLs.m
+++ b/TelegramTest/NSString+FindURLs.m
@@ -29,7 +29,7 @@
 
 - (NSArray *)locationsOfLinks
 {
-   
+    //detect range of links
     NSDataDetector *detect = [[NSDataDetector alloc] initWithTypes:1ULL << 5 error:nil];
     
     
@@ -37,6 +37,7 @@
     
     NSError *error = nil;
     
+    //detect range of @ (usernames)
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"((?<!\\w)@[\\w]{5,100}+)" options:NSRegularExpressionCaseInsensitive error:&error];
     
     NSMutableArray* userNames = [[regex matchesInString:self options:0 range:NSMakeRange(0, [self length])] mutableCopy];
@@ -62,6 +63,19 @@
         
         
     }];
+    
+    //detect range of URL Schemes
+    
+    // Run the following command to have a list of schemes available
+    //System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -dump | egrep "(bindings.*\:$)"|sort
+    
+    
+    //Load the list on the first run to memory
+    
+    
+    //check the contents of messages against the schemes (Regex or other?)
+    
+    //return the range of URL scheme to program
     
    return [results arrayByAddingObjectsFromArray:userNames];
 }

--- a/TelegramTest/NSString+FindURLs.m
+++ b/TelegramTest/NSString+FindURLs.m
@@ -7,6 +7,7 @@
 //
 
 #import "NSString+FindURLs.h"
+#import "FileUtils.h"
 
 @implementation NSString (NSString_FindURLs)
 
@@ -65,12 +66,13 @@
     }];
     
     //Load the list on the regex
-    NSArray *schemesToFind = @[@"spotify:", @"x-apple.systempreferences://"]; //dumb version
+    NSArray *schemesToFind = urlSchemes();
     NSString *schemeRegexString = @"";
     for (NSString *scheme in schemesToFind) {
-        schemeRegexString = [schemeRegexString stringByAppendingString:[NSString stringWithFormat:@"(%@.+)|", scheme]];
+        //explaining the regex: for example, if "spotify:" (open spotify) and "x-apple.systempreferences:" (open system preference) is on the array, the final regex will be /(spotify:\S*)| (x-apple.systempreferences:\S*)" witch says: "find the letters 'spotify:', in this order, followed by or not by any charachter until any whitespace is found OR find the letters 'x-apple.systempreferences:', in this order, followed by or not by any charachter until any whitespace is found"
+        schemeRegexString = [schemeRegexString stringByAppendingString:[NSString stringWithFormat:@"(%@\\S*)|", scheme]];
     }
-    //remove last character of string |
+    //remove last character of string "|"
     schemeRegexString = [schemeRegexString substringToIndex:schemeRegexString.length-(schemeRegexString.length>0)];
     
     //detect occurence of array into string
@@ -88,8 +90,8 @@
 
 
 /*
- //the following code has been commented because there's no programatic way of determining all the URL shchemes presented on a system, thus forcing the creation of the .plist for handling known URL schemes
--(NSArray *) listOfURIsOnTheSystem {
+ //the following code has been commented because there's no programatic way of determining all the URL schemes presented on a system, thus forcing the creation of the .txt for handling known URL schemes
+ -(NSArray *) listOfURIsOnTheSystem {
     NSPipe *pipe = [NSPipe pipe];
     NSFileHandle *file = pipe.fileHandleForReading;
     

--- a/TelegramTest/known-url-schemes.txt
+++ b/TelegramTest/known-url-schemes.txt
@@ -1,0 +1,5 @@
+spotify:
+x-apple.systempreferences:
+skype:
+magnet:
+twitter:


### PR DESCRIPTION
So, me and my friends share Spotify tracks on Telegram a lot using Spotify's URL Scheme, and I wanted to just click and "Bang" Spotify playing the jam.

I modified the methods recognising links.com and @users to also detect schemes and the if statement on the opening of links to open the schemes properly.
To make things easy for adding other schemes later, I created a .txt file called "known-url-schemes.txt".
Here's a gif showing the modification working:
![telegram and spotify](https://cloud.githubusercontent.com/assets/2848323/6259486/75dcc468-b7ba-11e4-8d21-75cec8ec3efc.gif)

Keep up with the awesome work on Telegram for OS X, by far my main reason to move my massaging into telegram.

EDIT: Re-arranged some of the work and made a new pull request.