### PR TITLE
FIX security issue

### DIFF
--- a/ASCommon.m
+++ b/ASCommon.m
@@ -77,11 +77,11 @@ void TGLogToFilev(NSString *format, va_list args)
 {
     NSString *message = [[NSString alloc] initWithFormat:format arguments:args];
     
-    //BOOL result = [[NSProcessInfo processInfo].environment[@"console_logging"] boolValue];
+    BOOL result = [[NSProcessInfo processInfo].environment[@"console_logging"] boolValue];
     
-   // if(result) {
+    if(result) {
         NSLog(@"%@", message);
-   // }
+    }
     
     dispatch_async(TGLogQueue(), ^
     {


### PR DESCRIPTION
All messages, even encrypted/secret ones, are put into the system log in plain text. This is because of commit https://github.com/overtake/telegram/commit/fc0d05d576da6ab792beeac8b91ddc280e666839 in which a condition checking the environment was decativated. this pull request reactivates the condition

fixes #313