### PR TITLE
Fix scroll direction in Stickers' horizontal scroll view

### DIFF
--- a/TelegramTest/TGTransformScrollView.m
+++ b/TelegramTest/TGTransformScrollView.m
@@ -17,15 +17,12 @@
 }
 
 
-- (void) scrollWheel:(NSEvent *) event
+- (void)scrollWheel:(NSEvent *) event
 {
-    
-    
-    
     NSPoint scrollPoint = [[self contentView] bounds].origin;
-    
-    if(!isInverted)
+
     BOOL isInverted = event.isDirectionInvertedFromDevice;
+    if (!isInverted)
         scrollPoint.x += ([event scrollingDeltaY] + [event scrollingDeltaX]);
     else
         scrollPoint.x -= ([event scrollingDeltaY] + [event scrollingDeltaX]);

--- a/TelegramTest/TGTransformScrollView.m
+++ b/TelegramTest/TGTransformScrollView.m
@@ -17,7 +17,7 @@
 }
 
 
-- (void)scrollWheel:(NSEvent *) event
+- (void)scrollWheel:(NSEvent *)event
 {
     NSPoint scrollPoint = [[self contentView] bounds].origin;
 

--- a/TelegramTest/TGTransformScrollView.m
+++ b/TelegramTest/TGTransformScrollView.m
@@ -24,8 +24,8 @@
     
     NSPoint scrollPoint = [[self contentView] bounds].origin;
     
-    BOOL isInverted = [[[NSUserDefaults standardUserDefaults] objectForKey:@"com.apple.swipescrolldirection"] boolValue];
     if(!isInverted)
+    BOOL isInverted = event.isDirectionInvertedFromDevice;
         scrollPoint.x += ([event scrollingDeltaY] + [event scrollingDeltaX]);
     else
         scrollPoint.x -= ([event scrollingDeltaY] + [event scrollingDeltaX]);


### PR DESCRIPTION
Hi,

I can’t build and run the app locally (because of submodules). But I’m pretty sure that I don’t have `com.apple.swipescrolldirection` key in defaults. So right now (2.21.50010), the Stickers' horizontal scroll view is scrolling in opposite direction.

Here is an event-based fix to detect scroll direction. (But I haven't tested it, and can’t make sure it works correctly.)
