### PR TITLE
Better emoji autocomplete UX

### DIFF
--- a/TelegramTest/AppDelegate.m
+++ b/TelegramTest/AppDelegate.m
@@ -741,7 +741,14 @@ void exceptionHandler(NSException * exception)
                 [TMViewController becomePasslock];
             }
         }
-
+        
+        // This section blocks tab keystrokes from propagating. 
+        // Not sure whether it is still needed, hence commenting out first.
+        // if(result.keyCode == 48) {
+        //   //  NSTextView *textView = responder;
+        //     return [[NSEvent alloc]init];
+        // }
+        
         if(isEnterAccess(result)) {
             if([appWindow().navigationController.currentController proccessEnterAction]) {
                 return [[NSEvent alloc] init];

--- a/TelegramTest/AppDelegate.m
+++ b/TelegramTest/AppDelegate.m
@@ -527,7 +527,10 @@ void exceptionHandler(NSException * exception)
         }
         
         if(incomingEvent.keyCode == 125 || incomingEvent.keyCode == 126) {
-            if(((incomingEvent.modifierFlags & (NSAlternateKeyMask)) > 0 || (incomingEvent.modifierFlags & (NSControlKeyMask)) > 0 || (incomingEvent.modifierFlags & (NSShiftKeyMask)) > 0 )&& incomingEvent.modifierFlags != 10617090) {
+            if(((incomingEvent.modifierFlags & (NSAlternateKeyMask)) > 0 || 
+                (incomingEvent.modifierFlags & (NSControlKeyMask)) > 0 || 
+                (incomingEvent.modifierFlags & (NSShiftKeyMask)) > 0)
+                && incomingEvent.modifierFlags != 10617090) {
                 BOOL result = YES;
                 
 //                if([responder isKindOfClass:[NSTextField class]]) {
@@ -738,14 +741,7 @@ void exceptionHandler(NSException * exception)
                 [TMViewController becomePasslock];
             }
         }
-        
-        if(result.keyCode == 48) {
-          //  NSTextView *textView = responder;
-            
-            
-            return [[NSEvent alloc]init];
-        }
-        
+
         if(isEnterAccess(result)) {
             if([appWindow().navigationController.currentController proccessEnterAction]) {
                 return [[NSEvent alloc] init];

--- a/TelegramTest/TGMessagesGrowingTextView.m
+++ b/TelegramTest/TGMessagesGrowingTextView.m
@@ -286,16 +286,14 @@
     
     
     if(!hint.isHidden) {
-        if(theEvent.keyCode == 125 || theEvent.keyCode == 126) {
-            
-            if(theEvent.keyCode == 125) {
+        if(theEvent.keyCode == 125 || theEvent.keyCode == 126 || theEvent.keyCode == 48) {
+            // (Down arrow key) or (Tab where modifier is not Shift).
+            if(theEvent.keyCode == 125 || (theEvent.keyCode == 48 && theEvent.modifierFlags != 131330)) {
                 [hint selectNext];
             } else {
                 [hint selectPrev];
             }
-            
             return;
-            
         }
         
         if(isEnterAccess(theEvent)) {
@@ -303,10 +301,7 @@
                 [hint performSelected];
                 return;
             }
-            
-            
         }
-        
     } else if(theEvent.keyCode == 126 && (self.string.length == 0)) {
         [self.weakd.messagesController forceSetEditSentMessage:NO];
         return;

--- a/TelegramTest/TGMessagesHintView.m
+++ b/TelegramTest/TGMessagesHintView.m
@@ -482,8 +482,9 @@ DYNAMIC_PROPERTY(DUser);
         [recentlyUsed enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
             [items addObject:[[TGMessagesHintRowItem alloc] initWithEmojiData:obj]];
         }];
-    } else {
-        // Else, filter the list of emojis to extract out those that match the query.
+    } else if (query.length >= 2) {
+        // Filter the list of emojis to extract out those that match a query 
+        // that is at least 2 characters.
         NSMutableArray *queryMatches = [NSMutableArray array];
         [emoji enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop) {
             if ([key rangeOfString:[query lowercaseString]].location != NSNotFound) {

--- a/TelegramTest/TGMessagesHintView.m
+++ b/TelegramTest/TGMessagesHintView.m
@@ -508,10 +508,12 @@ DYNAMIC_PROPERTY(DUser);
     
     [_tableView insert:items startIndex:0 tableRedraw:YES];
     
-    if(items.count > 0)
+    if(items.count > 0) {
         [self show:NO selectNext:NO];
-    else
+        [_tableView setSelectedObject:[_tableView itemAtPosition:0]];    
+    } else {
         [self hide];
+    }
     
 }
 


### PR DESCRIPTION
1. Always highlight one of the emoji hints, like for hashtag and tags.
2. Tab/Shift+Tab to scroll between emoji hints (I will implement for hashtags and tags later).
3. Only show hints when there are at least 2 characters present. Hence typing `:p` will not trigger the hints. Slack does this too. This is subjective, we can discuss further if you disagree with this 😄 

The screenshot below shows what happens when I type `:jo` into the text field, `:joy:` is highlighted and I can simply press enter to select it and continue typing, as opposed to pressing the down arrow key first to select it. This saves one keystroke (;

<img width="179" alt="screen shot 2017-01-15 at 9 43 11 pm" src="https://cloud.githubusercontent.com/assets/1315101/21962963/a2fd439c-db6b-11e6-85c1-3a2d1f736a3c.png">
