### PR TITLE
Show recent emojis higher within emoji hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Telegram for macOS
 ===========
 
-[Telegram](http://telegram.org) is a messaging app with a focus on speed and security. It’s superfast, simple and free.
+[Telegram](http://telegram.org) is a messaging app with a focus on speed and security. It’s super fast, simple and free.
 
 This repo contains official [Telegram for macOS](https://macos.telegram.org/) source code.
 
@@ -21,4 +21,4 @@ Documentation for MTproto protocol is available here: http://core.telegram.org/m
 
 ### License
 
-GPL V2
+GPL v2


### PR DESCRIPTION
Sort emoji hints that contain the query according to:
- Appearance in the recently used emoji list
- The starting index of the matching query within the emoji

Recently used emojis have higher priority over the other emojis that match the query.

For example, the user enters `:jo`. As of now four emojis match the query: `:joy:`, `:joy_cat:`, `:mahjong:`, `:black_joker:`. They appear in this order because of the position of substring `jo` within the matched word: 0, 0, 3, 6 respectively.

If `:mahjong:` is within the recently used list of emojis, `:mahjong:` will be given higher priority and it will appear in front before all others even though `jo` is index 3 within that `:mahjong:`.

Final order of emojis:  `:mahjong:`, `:joy:`, `:joy_cat:`, `:black_joker:`

@overtake have a look? 😄 