### PR TITLE
Fixed reply in notification deminiaturizing window

### DIFF
--- a/TelegramTest/AppDelegate.m
+++ b/TelegramTest/AppDelegate.m
@@ -245,13 +245,15 @@ static void TGTelegramLoggingFunction(NSString *format, va_list args)
         ELog(@"nil dialog here, check it");
         return;
     }
-    
-     [self.mainWindow deminiaturize:self];
+
     
     [self.mainWindow.navigationController showMessagesViewController:dialog];
     
-    
-    if (floor(NSAppKitVersionNumber) > 1187 && notification.activationType == 3) { //NSUserNotificationActivationTypeReplied)
+    if (notification.activationType != NSUserNotificationActivationTypeReplied) {
+        // only deminiaturize the window if user clicked the notification itself
+        // and not replied
+        [self.mainWindow deminiaturize:self];
+    } else if (floor(NSAppKitVersionNumber) > 1187 && notification.activationType == 3) { //NSUserNotificationActivationTypeReplied)
         NSString *userResponse = notification.response.string;
         
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -272,9 +274,6 @@ static void TGTelegramLoggingFunction(NSString *format, va_list args)
         
         return;
     }
-    
-   
-    
     
 }
 


### PR DESCRIPTION
Using reply feature on the notification was deminiaturizing the main window, even if the user was on other application, or even in full screen view.

Things get especially weird when in full screen mode. The window deminiaturizes and covers the screen and then goes into the background.

![telegram](https://cloud.githubusercontent.com/assets/7294931/22504264/e107a45e-e88e-11e6-9e45-283d2bf46689.gif)
