### PR TITLE
Fixes issue where usernames with greater than or less than appear wrong

### DIFF
--- a/TelegramTest/TLUserCategory.m
+++ b/TelegramTest/TLUserCategory.m
@@ -462,7 +462,7 @@ DYNAMIC_PROPERTY(DFullName);
         if(!self.last_name)
             self.last_name = @"";
         
-        NSString *fullName = [[[[NSString stringWithFormat:@"%@%@%@", self.first_name,self.first_name.length > 0 ? @" " : @"", self.last_name] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] singleLine] htmlentities];
+        NSString *fullName = [[[NSString stringWithFormat:@"%@%@%@", self.first_name,self.first_name.length > 0 ? @" " : @"", self.last_name] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] singleLine];
         if(fullName.length > 30)
             fullName = [fullName substringToIndex:30];
         


### PR DESCRIPTION
This resolves an issue where users with greater than or less than signs in their name appear to be html encoded.

Before patch:
<img width="190" alt="screen shot 2017-02-06 at 9 36 03 pm" src="https://cloud.githubusercontent.com/assets/234867/22644057/3a5d239c-ecb5-11e6-86f5-cbaf84f22fa7.png">

After patch:
<img width="156" alt="screen shot 2017-02-06 at 9 36 24 pm" src="https://cloud.githubusercontent.com/assets/234867/22644058/3a5d3864-ecb5-11e6-9d49-2e207884c9fb.png">
