### PR TITLE
Fix for long full names being not nicely cut off

### DIFF
--- a/TelegramTest/TLUserCategory.m
+++ b/TelegramTest/TLUserCategory.m
@@ -462,9 +462,7 @@ DYNAMIC_PROPERTY(DFullName);
         if(!self.last_name)
             self.last_name = @"";
         
-        NSString *fullName = [[[[NSString stringWithFormat:@"%@%@%@", self.first_name,self.first_name.length > 0 ? @" " : @"", self.last_name] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] singleLine] htmlentities];
-        if(fullName.length > 30)
-            fullName = [fullName substringToIndex:30];
+        NSString *fullName = [[[NSString stringWithFormat:@"%@%@%@", self.first_name,self.first_name.length > 0 ? @" " : @"", self.last_name] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] singleLine];
         
         
         [self setDFullName:fullName];
@@ -655,10 +653,6 @@ DYNAMIC_PROPERTY(STATUS_CHAT_HEADER);
     
     
     userName = [userName singleLine];
-    
-    if(userName.length > 30)
-        userName = [userName substringToIndex:30];
-    
     
     return userName;
 }

--- a/TelegramTest/UsersManager.m
+++ b/TelegramTest/UsersManager.m
@@ -440,9 +440,9 @@
 
 -(void)updateAccount:(NSString *)firstName lastName:(NSString *)lastName completeHandler:(void (^)(TLUser *))completeHandler errorHandler:(void (^)(NSString *))errorHandler {
     
-    firstName = firstName.length > 30 ? [firstName substringToIndex:30] : firstName;
+    firstName = firstName.length > 255 ? [firstName substringToIndex:255] : firstName;
     
-    lastName = lastName.length > 30 ? [lastName substringToIndex:30] : lastName;
+    lastName = lastName.length > 255 ? [lastName substringToIndex:255] : lastName;
     
     
     if([firstName isEqualToString:self.userSelf.first_name] && [lastName isEqualToString:self.userSelf.last_name])


### PR DESCRIPTION
This patch allows for longer names. Tested with longest name telegram supports (255 chars)